### PR TITLE
fix: Latest version of github-pages-deploy-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: ng build
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@latest
         with:
           branch: gh-pages
           folder: dist/quizapp


### PR DESCRIPTION
This pull request addresses an issue with the version of `github-pages-deploy-action` used in our GitHub Actions workflow.

Changes included in this PR:

- Updated the version of `github-pages-deploy-action` in `.github/workflows/main.yml` to use the latest.

The previous version reference (`JamesIves/github-pages-deploy-action@4`) caused an error as this version could not be found. We've updated this to use the latest version that exists (`JamesIves/github-pages-deploy-action@latest`).

By fixing this, we expect our CI/CD pipeline to run successfully upon merging changes to the `main` branch. 

