### PR TITLE
fix: Correct version of github-pages-deploy-action (@v4 instead of @latest)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: ng build
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@latest
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: dist/quizapp


### PR DESCRIPTION
This pull request addresses an issue with the version of `github-pages-deploy-action` used in our GitHub Actions workflow.

Changes included in this PR:

- Updated the version of `github-pages-deploy-action` in `.github/workflows/main.yml`.

The previous version reference (`JamesIves/github-pages-deploy-action@latest`) caused an error as this version could not be found. We've updated this to use a specific version that exists (`JamesIves/github-pages-deploy-action@v4`).


