### PR TITLE
fix: Update actions/checkout and actions/setup-node to v3 and node.js to version to 16 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
This pull request addresses a warning regarding the Node.js version used in our GitHub Actions workflow.

Changes included in this PR:

- Updated the `actions/checkout` action to v3.
- - Updated the `actions/setup-node` action to v3.
- Set the Node.js version to 16 in the `actions/setup-node` step of our workflow.

Previously, we were using an older version of Node.js (14) and v2 of the `actions/checkout` and  `actions/setup-node`action. The older Node.js version was being deprecated, leading to a warning message in our workflow runs.
