### PR TITLE
test: configure karma to use ChromeHeadless for CI

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,37 @@
+// karma.conf.js
+module.exports = function (config) {
+    config.set({
+      basePath: '',
+      frameworks: ['jasmine', '@angular-devkit/build-angular'],
+      plugins: [
+        require('karma-jasmine'),
+        require('karma-chrome-launcher'),
+        require('karma-jasmine-html-reporter'),
+        require('karma-coverage-istanbul-reporter'),
+        require('@angular-devkit/build-angular/plugins/karma')
+      ],
+      client: {
+        clearContext: false // leave Jasmine Spec Runner output visible in browser
+      },
+      coverageIstanbulReporter: {
+        dir: require('path').join(__dirname, './coverage'),
+        reports: ['html', 'lcovonly', 'text-summary'],
+        fixWebpackSourcePaths: true
+      },
+      reporters: ['progress', 'kjhtml'],
+      port: 9876,
+      colors: true,
+      logLevel: config.LOG_INFO,
+      autoWatch: true,
+      browsers: ['ChromeHeadlessCI'], // updated
+      customLaunchers: { // added
+        ChromeHeadlessCI: {
+          base: 'ChromeHeadless',
+          flags: ['--no-sandbox']
+        }
+      },
+      singleRun: false,
+      restartOnFileChange: true,
+    });
+  };
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -10315,9 +10315,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
+      "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
This PR introduces changes to the Karma configuration to run the tests in a headless Chrome browser. This is particularly useful for CI environments where a display is not available. Before the git action workflow wasn't able to launch a chrome browser instance for running the tests.

Changes:
- Created the `karma.conf.js` file
- Added a custom browser launcher, `ChromeHeadlessCI`, in the `karma.conf.js`.
- This launcher uses the `ChromeHeadless` base and includes the `--no-sandbox` flag, which is required for running Chrome in headless mode in some CI environments.
- Updated the `browsers` configuration to use the new `ChromeHeadlessCI` launcher.

These changes aim to ensure that the test suite runs smoothly in the GitHub Actions CI/CD pipeline.
