### PR TITLE
test: add secret github token to allow github-actions to push to the gh-pages branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,5 +27,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: dist/quizapp


### PR DESCRIPTION
error before:
remote: Permission to cheykoff/quizapp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/cheykoff/quizapp.git/': The requested URL returned error: 403

change: 
name: Deploy to GitHub Pages
        uses: JamesIves/github-pages-deploy-action@v4
        with:
          **token: ${{ secrets.GITHUB_TOKEN }}**
          branch: gh-pages
          folder: dist/quizapp
